### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Version 1.1.0
+**2023-11-21**
+
+- Bump certifi from 2023.7.22 to 2023.11.17 (#40) @dependabot
+- Bump rich from 13.6.0 to 13.7.0 (#38) @dependabot
+- Bump urllib3 from 2.0.7 to 2.1.0 (#37) @dependabot
+- Bump charset-normalizer from 3.3.1 to 3.3.2 (#36) @dependabot
+
 ## Version 1.0.0
 **2022-11-22**
 


### PR DESCRIPTION
- Bump certifi from 2023.7.22 to 2023.11.17 (#40) @dependabot
- Bump rich from 13.6.0 to 13.7.0 (#38) @dependabot
- Bump urllib3 from 2.0.7 to 2.1.0 (#37) @dependabot
- Bump charset-normalizer from 3.3.1 to 3.3.2 (#36) @dependabot